### PR TITLE
cogs.utils.github: Make complete [diff] clickable

### DIFF
--- a/obsbot/cogs/public/utils/github.py
+++ b/obsbot/cogs/public/utils/github.py
@@ -190,7 +190,7 @@ class GitHubHelper:
         for page in event_body['pages']:
             diff_url = f'{page["html_url"]}/_compare/{page["sha"]}^...{page["sha"]}'
             page_url = f'{page["html_url"]}/{page["sha"]}'
-            body.append(f'**{page["action"]}:** [{page["title"]}]({page_url}) [[diff]({diff_url})]')
+            body.append(f'**{page["action"]}:** [{page["title"]}]({page_url}) [[diff]]({diff_url})')
         embed.description = '\n'.join(body)
         return embed
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
This makes the complete `[diff]` clickable when someone edited a Wiki page, instead of just `[diff`.
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
It looks odd when only one bracket is highlighted.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
/
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
 Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
