### PR TITLE
cogs.factoids: Update bot replies

### DIFF
--- a/obsbot/cogs/public/factoids.py
+++ b/obsbot/cogs/public/factoids.py
@@ -163,6 +163,14 @@ class Factoids(Cog):
         user_mention = None
         if msg.mentions and not msg.reference:
             user_mention = ' '.join(user.mention for user in msg.mentions)
+            
+        # if message is replying to bot message that is replying to a message, reply to original message
+        send_reference = None
+        if msg.reference:
+          if msg.reference.resolved.author == self.bot.user and msg.reference.resolved.reference:
+            send_reference = msg.reference.resolved.reference
+          else:
+            send_reference = msg.reference
 
         embed = None
         if factoid['embed']:
@@ -176,7 +184,7 @@ class Factoids(Cog):
         elif user_mention:
             return await msg.channel.send(f'{user_mention} {message}')
         else:
-            return await msg.channel.send(message, embed=embed, reference=msg.reference, mention_author=True)
+            return await msg.channel.send(message, embed=embed, reference=send_reference, mention_author=True)
 
     async def increment_uses(self, factoid_name):
         return await self.bot.db.add_task(


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
If a factoid is sent and replies to a bot message that is already replying to a message, have the new factoid reply to the original message.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
suggestion from the discord 
https://discord.com/channels/348973006581923840/376042662580715521/945818314633007234

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on my own personal bot that was built based off the factoids code from OBS bot so the main code is the same and lines up with the OBS bot code.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
 - New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
