### PR TITLE
cogs.public.log_analysis: Add filtering for broken video capture devices

### DIFF
--- a/obsbot/cogs/public/log_analysis.py
+++ b/obsbot/cogs/public/log_analysis.py
@@ -26,6 +26,7 @@ class LogAnalyser(Cog):
     _log_analyser_failed = '❌'
 
     _filtered_log_needles = ('obs-streamelements.dll', 'ftl_stream_create')
+    _filtered_log_brokenvideocapture = ('warning: Found EOI before any SOF, ignoring', 'fatal:   No JPEG data found in image', 'Error decoding video')
     _log_hosts = (
         'https://obsproject.com/logs/',
         'https://hastebin.com/',
@@ -174,11 +175,24 @@ class LogAnalyser(Cog):
                 if hardware_check_msg := self.hardware_check(hw_results):
                     embed.add_field(name='Hardware Check', inline=False, value=' / '.join(hardware_check_msg))
 
-            # include filtered log in case SE or FTL spam is detected
-            if 'obsproject.com' in log_url and any(elem in log_content for elem in self._filtered_log_needles):
+            # include filtered log in case SE, FTL, or broken video capture device spam is detected
+			if 'obsproject.com' in log_url and any(elem in log_content for elem in self._filtered_log_needles) and any(elem in log_content for elem in self._filtered_log_brokenvideocapture):
+                clean_url = log_url.replace('obsproject.com', 'obsbot.rodney.io')
+                embed.description = (
+                    f'*Log contains debug messages (browser/ftl/etc) '
+                    f'and a broken video capture device, '
+                    f'for a filtered version [click here]({clean_url})*\n'
+                )
+            else if 'obsproject.com' in log_url and any(elem in log_content for elem in self._filtered_log_needles):
                 clean_url = log_url.replace('obsproject.com', 'obsbot.rodney.io')
                 embed.description = (
                     f'*Log contains debug messages (browser/ftl/etc), '
+                    f'for a filtered version [click here]({clean_url})*\n'
+                )
+			else if 'obsproject.com' in log_url and any(elem in log_content for elem in self._filtered_log_brokenvideocapture):
+				clean_url = log_url.replace('obsproject.com', 'obsbot.rodney.io')
+                embed.description = (
+                    f'*A broken video capture device is present, '
                     f'for a filtered version [click here]({clean_url})*\n'
                 )
 


### PR DESCRIPTION
### Description
Add a warning and link to a filtered log if a log contains spam from a broken video capture device. Depends on a minor change to logs.lua on Rodney's end. See https://discord.com/channels/348973006581923840/374636084883095554/990274591119265822 .

### Motivation and Context
Some devices, especially cheap capture cards and webcams, sometimes emit messages like this:

11:05:27.466: warning: Found EOI before any SOF, ignoring
11:05:27.466: fatal:   No JPEG data found in image
11:05:27.466: Error decoding video

There is code to be added to logs.lua ( see https://discord.com/channels/348973006581923840/374636084883095554/990274591119265822 ) that will remove instances of these. The changes in this PR cause OBSBot to emit a slightly different message than the usual one when this happens, so that mobile users who cannot run Grep for themselves can see that there was a broken video capture device, while still getting the benefit of a cleaner log.

### How Has This Been Tested?
It has not.

### Types of changes
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->

### Checklist:
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [ ] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
